### PR TITLE
bitrate: fix build warning

### DIFF
--- a/enigma2-plugin-extensions-bitrate.bb
+++ b/enigma2-plugin-extensions-bitrate.bb
@@ -8,7 +8,7 @@ require openplugins.inc
 
 inherit autotools
 
-EXTRA_OECONF = "--with-boxtype=${MACHINE} \
+EXTRA_OECONF = " \
     STAGING_INCDIR=${STAGING_INCDIR} \
     STAGING_LIBDIR=${STAGING_LIBDIR}"
 


### PR DESCRIPTION
`WARNING: enigma2-plugin-extensions-bitrate-2.0+gitAUTOINC+edca14d426-r1 do_configure: QA Issue: enigma2-plugin-extensions-bitrate: configure was passed unrecognised options: --with-boxtype [unknown-configure-option]`
remove this configure option, it's obsolete since 2011