### PR TITLE
owif: move source files to src package

### DIFF
--- a/enigma2-plugin-extensions-openwebif.bb
+++ b/enigma2-plugin-extensions-openwebif.bb
@@ -26,7 +26,7 @@ require openplugins-distutils.inc
 # Just a quick hack to "compile" it
 do_compile() {
 	cheetah-compile -R --nobackup ${S}/plugin
-	python -O -m compileall ${S}
+	python -O -m compileall -d ${PLUGINPATH} ${S}/plugin
 }
 
 PLUGINPATH = "/usr/lib/enigma2/python/Plugins/Extensions/${MODULE}"
@@ -36,4 +36,7 @@ do_install_append() {
 	chmod a+rX ${D}${PLUGINPATH}
 }
 
+PACKAGES =+ "${PN}-src"
+FILES_${PN}-src = "${PLUGINPATH}/*.py ${PLUGINPATH}/*/*.py ${PLUGINPATH}/*/*/*.py ${PLUGINPATH}/*/*/*/*.py ${PLUGINPATH}/*/*/*/*/*.py \
+		${PLUGINPATH}/controllers/views/*.tmpl ${PLUGINPATH}/controllers/views/*/*.tmpl ${PLUGINPATH}/controllers/views/*/*/*.tmpl"
 FILES_${PN} = "${PLUGINPATH}"


### PR DESCRIPTION
Provide a separate package with py and tmpl files to reduce size about 3MB.
Also provide proper path to tracebacks using compileall parameter destdir.