### PR TITLE
Add missing gettext and python depends to allow build with newer OE

### DIFF
--- a/enigma2-plugin-extensions-bitrate.bb
+++ b/enigma2-plugin-extensions-bitrate.bb
@@ -6,7 +6,9 @@ PR="r1"
 
 require openplugins.inc
 
-inherit autotools
+inherit autotools gettext
+
+DEPENDS += "python"
 
 EXTRA_OECONF = " \
     STAGING_INCDIR=${STAGING_INCDIR} \

--- a/enigma2-plugin-systemplugins-autobouquetsmaker.bb
+++ b/enigma2-plugin-systemplugins-autobouquetsmaker.bb
@@ -5,7 +5,9 @@ PACKAGE_ARCH = "${MACHINE_ARCH}"
 LICENSE = "Proprietary"
 LIC_FILES_CHKSUM = "file://LICENSE;md5=84dcc94da3adb52b53ae4fa38fe49e5d"
 
-inherit autotools-brokensep gitpkgv pythonnative
+inherit autotools-brokensep gitpkgv pythonnative gettext
+
+DEPENDS += "python"
 
 PV = "2.1+git${SRCPV}"
 PKGV = "2.1+git${GITPKGV}"

--- a/enigma2-plugin-systemplugins-autoshutdown.bb
+++ b/enigma2-plugin-systemplugins-autoshutdown.bb
@@ -10,7 +10,7 @@ PR = "r0"
 
 require openplugins.inc
 
-inherit autotools
+inherit autotools gettext
 
 FILES_${PN} = "/"
 


### PR DESCRIPTION
Newer OE requires inherit gettext in order to use localization tools.
Also python depend seems to solved issues bulding bitrate.

Maybe we should check configure.ac and confirm if the following still required.

AM_PATH_PYTHON()
AC_PYTHON_DEVEL